### PR TITLE
[MWAR-441] - Allow "outdatedCheckPath" parameter to be set to cover web app dir root (everything in the web app directory)

### DIFF
--- a/src/it/MWAR-441/invoker.properties
+++ b/src/it/MWAR-441/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals.1=package
+invoker.goals.2=groovy:execute
+invoker.goals.3=package

--- a/src/it/MWAR-441/pom.xml
+++ b/src/it/MWAR-441/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.war</groupId>
+  <artifactId>mwar427</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>war</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <archiveClasses>true</archiveClasses>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>groovy-maven-plugin</artifactId>
+        <version>2.0</version>
+        <configuration>
+          <source>
+            def fileToModify = new File(project.basedir, 'pom.xml')
+            processFileInplace(fileToModify) { text ->
+              text.replaceAll(/1.4.6/,'1.4.5')
+            }
+            def processFileInplace(file, Closure processText) {
+              file.write(processText(file.text))
+            }
+            
+            new File('src/main/webapp/root.html').renameTo 'src/main/webapp/index.html'
+          </source>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.21</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>1.4.6</version>
+    </dependency>
+  </dependencies>
+  
+</project>

--- a/src/it/MWAR-441/pom.xml
+++ b/src/it/MWAR-441/pom.xml
@@ -39,6 +39,7 @@ under the License.
         <version>@project.version@</version>
         <configuration>
           <archiveClasses>true</archiveClasses>
+          <outdatedCheckPath>/</outdatedCheckPath>
         </configuration>
       </plugin>
       <plugin>

--- a/src/it/MWAR-441/src/main/resources/resource.txt
+++ b/src/it/MWAR-441/src/main/resources/resource.txt
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/MWAR-441/src/main/webapp/root.html
+++ b/src/it/MWAR-441/src/main/webapp/root.html
@@ -1,0 +1,23 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<html>
+  <body>
+    Hello World
+  </body>
+</html>

--- a/src/it/MWAR-441/verify.groovy
+++ b/src/it/MWAR-441/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def warFile = new java.util.jar.JarFile( new File(basedir,"target/mwar427-1.0-SNAPSHOT.war"), false)
+assert warFile.getEntry('WEB-INF/lib/plexus-utils-1.4.5.jar') != null
+assert warFile.getEntry('WEB-INF/lib/mwar427-1.0-SNAPSHOT.jar') != null
+assert warFile.getEntry('index.html') != null
+
+assert warFile.getEntry('WEB-INF/lib/plexus-utils-1.4.6.jar') == null
+assert warFile.getEntry('root.html') != null // after MWAR-433, only WEB-INF/lib/ content is checked, other resources may be generated outside m-war-p

--- a/src/it/MWAR-441/verify.groovy
+++ b/src/it/MWAR-441/verify.groovy
@@ -23,4 +23,4 @@ assert warFile.getEntry('WEB-INF/lib/mwar427-1.0-SNAPSHOT.jar') != null
 assert warFile.getEntry('index.html') != null
 
 assert warFile.getEntry('WEB-INF/lib/plexus-utils-1.4.6.jar') == null
-assert warFile.getEntry('root.html') != null // after MWAR-433, only WEB-INF/lib/ content is checked, other resources may be generated outside m-war-p
+assert warFile.getEntry('root.html') == null // after MWAR-441, this path is also removed as outdated (with the '/' config in the pom).

--- a/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
@@ -365,6 +365,9 @@ public abstract class AbstractWarMojo
     /**
      * Path prefix for resources that will be checked against outdated content.
      *
+     * Starting with <b>3.3.2</b>, if a value of "/" is specified the entire
+     * webappDirectory will be checked, i.e. the "/" signifies "root".
+     *
      * @since 3.3.1
      */
     @Parameter( defaultValue = "WEB-INF/lib/" )
@@ -650,7 +653,10 @@ public abstract class AbstractWarMojo
                 {
                     if ( '\\' == File.separatorChar )
                     {
-                        outdatedCheckPath = outdatedCheckPath.replace( '/', '\\' );
+                        if ( ! checkAllPathsForOutdated() )
+                        {
+                            outdatedCheckPath = outdatedCheckPath.replace( '/', '\\' );
+                        }
                     }
                     Files.walkFileTree( webappDirectory.toPath(), new SimpleFileVisitor<Path>()
                     {
@@ -660,9 +666,8 @@ public abstract class AbstractWarMojo
                         {
                             if ( file.toFile().lastModified() < session.getStartTime().getTime() )
                             {
-                                // resource older than session build start
                                 String path = webappDirectory.toPath().relativize( file ).toString();
-                                if ( path.startsWith( outdatedCheckPath ) )
+                                if ( checkAllPathsForOutdated() || path.startsWith( outdatedCheckPath ) )
                                 {
                                     outdatedResources.add( path );
                                 }
@@ -677,6 +682,11 @@ public abstract class AbstractWarMojo
                 }
             }
             this.outputTimestamp = outputTimestamp;
+        }
+
+        protected boolean checkAllPathsForOutdated() 
+        {
+            return outdatedCheckPath.equals( "/" );
         }
 
         @Override


### PR DESCRIPTION
Following this checklist to help us incorporate your contribution quickly and easily:

 - [X ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MWAR) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[MWAR-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MWAR-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

### WHY THIS IS ACTUALLY A SMALL CHANGE

If you step through the three commits you'll see it's just
1. ten lines of plugin code change
2. cloned an earlier IT dir
3. made a few lines of changes to that one for the new IT's logic  (didn't see how to tack that on to the earlier test w/o clone).