### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
@@ -400,7 +400,7 @@ public abstract class AbstractWarMojo
     protected String[] getExcludes()
     {
         List<String> excludeList = new ArrayList<>();
-        if ( StringUtils.isNotEmpty( warSourceExcludes ) )
+        if ( warSourceExcludes != null && !warSourceExcludes.isEmpty() )
         {
             excludeList.addAll( Arrays.asList( StringUtils.split( warSourceExcludes, "," ) ) );
         }

--- a/src/main/java/org/apache/maven/plugins/war/WarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/war/WarMojo.java
@@ -411,7 +411,7 @@ public class WarMojo
      */
     public String[] getPackagingExcludes()
     {
-        if ( StringUtils.isEmpty( packagingExcludes ) )
+        if ( packagingExcludes == null || packagingExcludes.isEmpty() )
         {
             return new String[0];
         }
@@ -434,7 +434,7 @@ public class WarMojo
      */
     public String[] getPackagingIncludes()
     {
-        if ( StringUtils.isEmpty( packagingIncludes ) )
+        if ( packagingIncludes == null || packagingIncludes.isEmpty() )
         {
             return new String[] { "**" };
         }


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu