### PR TITLE
Make sure Plexus AbstractLogEnabled is not used (extended) any more

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,11 @@
       <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
 
     <dependency>
       <!-- looks up RepositorySystem -->


### PR DESCRIPTION
Maven since 3.x uses SLF4J API instead.


