### PR TITLE
fix: correct inverted equality checks in WarUtils.isRelated()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/util/WarUtils.java
+++ b/src/main/java/org/apache/maven/plugins/war/util/WarUtils.java
@@ -66,16 +66,16 @@ public class WarUtils {
         if (!Objects.equals(artifact.getArtifactId(), dependency.getArtifactId())) {
             return false;
         }
-        if (Objects.equals(artifact.getVersion(), dependency.getVersion())) {
+        if (!Objects.equals(artifact.getVersion(), dependency.getVersion())) {
             return false;
         }
-        if (Objects.equals(artifact.getType(), dependency.getType())) {
+        if (!Objects.equals(artifact.getType(), dependency.getType())) {
             return false;
         }
-        if (Objects.equals(artifact.getClassifier(), dependency.getClassifier())) {
+        if (!Objects.equals(artifact.getClassifier(), dependency.getClassifier())) {
             return false;
         }
-        if (Objects.equals(artifact.getScope(), dependency.getScope())) {
+        if (!Objects.equals(artifact.getScope(), dependency.getScope())) {
             return false;
         }
         if (artifact.isOptional() != dependency.isOptional()) {


### PR DESCRIPTION
Fixes #619

`WarUtils.isRelated()` returned `false` when `version`, `type`, `classifier`, or `scope` were *equal* between artifact and dependency — the opposite of the intended logic (should return `false` only when they *differ*).  This made `registerTargetFileName()` in `WebappStructure` effectively broken.