### PR TITLE
fix: make DependencyInfo.hashCode() consistent with equals()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/util/DependencyInfo.java
+++ b/src/main/java/org/apache/maven/plugins/war/util/DependencyInfo.java
@@ -85,9 +85,6 @@ public class DependencyInfo {
 
     @Override
     public int hashCode() {
-        int result;
-        result = (dependency != null ? dependency.hashCode() : 0);
-        result = 31 * result + (targetFileName != null ? targetFileName.hashCode() : 0);
-        return result;
+        return dependency != null ? dependency.hashCode() : 0;
     }
 }


### PR DESCRIPTION
Fixes #620

`equals()` compares only the `dependency` field, but `hashCode()` incorrectly incorporated both `dependency` and `targetFileName`, violating the equals/hashCode contract and causing incorrect behavior in hash-based collections.