### PR TITLE
fix: treat null classifier as empty string in OverlayManager

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/overlay/OverlayManager.java
+++ b/src/main/java/org/apache/maven/plugins/war/overlay/OverlayManager.java
@@ -203,7 +203,7 @@ public class OverlayManager {
                 && Objects.equals(overlay.getType(), artifact.getType())
                 // MWAR-241 Make sure to treat null and "" as equal when comparing the classifier
                 && Objects.equals(
-                        Objects.toString(overlay.getClassifier()), Objects.toString(artifact.getClassifier())));
+                        Objects.toString(overlay.getClassifier(), ""), Objects.toString(artifact.getClassifier(), "")));
     }
 
     /**


### PR DESCRIPTION
Fixes #621

`Objects.toString(x)` converts `null` to the literal string `"null"`, not `""`. This caused overlay-to-artifact matching to fail when one side had a null classifier and the other had an empty string, contradicting the documented MWAR-241 intent.