### PR TITLE
fix: treat null classifier as empty string in OverlayManager

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/overlay/OverlayManager.java
+++ b/src/main/java/org/apache/maven/plugins/war/overlay/OverlayManager.java
@@ -203,7 +203,7 @@ public class OverlayManager {
                 && Objects.equals(overlay.getType(), artifact.getType())
                 // MWAR-241 Make sure to treat null and "" as equal when comparing the classifier
                 && Objects.equals(
-                        Objects.toString(overlay.getClassifier()), Objects.toString(artifact.getClassifier())));
+                        Objects.toString(overlay.getClassifier(), ""), Objects.toString(artifact.getClassifier(), "")));
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugins/war/overlay/OverlayManagerTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/overlay/OverlayManagerTest.java
@@ -126,6 +126,25 @@ class OverlayManagerTest {
     }
 
     @Test
+    void testNullClassifierMatchesEmptyClassifier() throws Exception {
+        final MavenProjectArtifactsStub project = new MavenProjectArtifactsStub();
+        final ArtifactStub artifact = newWarArtifact("test", "test-webapp", "");
+        project.addArtifact(artifact);
+
+        final List<Overlay> overlays = new ArrayList<>();
+        Overlay overlay = new Overlay("test", "test-webapp");
+        overlay.setClassifier(null);
+        overlay.setType("war");
+        overlays.add(overlay);
+
+        final Overlay currentProjectOverlay = Overlay.createInstance();
+        OverlayManager manager =
+                new OverlayManager(overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES, currentProjectOverlay);
+        assertNotNull(manager.getOverlays());
+        assertEquals(2, manager.getOverlays().size());
+    }
+
+    @Test
     void testOverlaysWithSameArtifactAndGroupId() throws Exception {
 
         final MavenProjectArtifactsStub project = new MavenProjectArtifactsStub();

--- a/src/test/java/org/apache/maven/plugins/war/overlay/OverlayManagerTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/overlay/OverlayManagerTest.java
@@ -31,6 +31,7 @@ import static org.apache.maven.plugins.war.Overlay.DEFAULT_EXCLUDES;
 import static org.apache.maven.plugins.war.Overlay.DEFAULT_INCLUDES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -142,6 +143,8 @@ class OverlayManagerTest {
                 new OverlayManager(overlays, project, DEFAULT_INCLUDES, DEFAULT_EXCLUDES, currentProjectOverlay);
         assertNotNull(manager.getOverlays());
         assertEquals(2, manager.getOverlays().size());
+        assertEquals(currentProjectOverlay, manager.getOverlays().get(0));
+        assertSame(artifact, manager.getOverlays().get(1).getArtifact());
     }
 
     @Test


### PR DESCRIPTION
Fixes #621

`Objects.toString(x)` converts `null` to the literal string `"null"`, not `""`. This caused overlay-to-artifact matching to fail when one side had a null classifier and the other had an empty string, contradicting the documented MWAR-241 intent.

Includes TDD: wrote failing test (null-classifier overlay vs empty-classifier artifact throws `InvalidOverlayConfigurationException`), then applied the fix.