### PR TITLE
Fix errors, typos, grammar, and broken link in site documentation

### DIFF
--- a/src/site/apt/examples/rapid-testing-jetty6-plugin.apt
+++ b/src/site/apt/examples/rapid-testing-jetty6-plugin.apt
@@ -72,4 +72,4 @@ Rapid Testing Using the Jetty Plugin
 
  The command will block with Jetty listening on port 8080.
 
- Check the {{{http://docs.codehaus.org/display/JETTY/Maven+Jetty+Plugin}Jetty Plugin documentation}} for more details.
+  Check the {{{https://jetty.org/docs/jetty/12/programming-guide/maven-jetty/jetty-maven-plugin.html}Jetty Plugin documentation}} for more details.

--- a/src/site/apt/examples/war-manifest-guide.apt.vm
+++ b/src/site/apt/examples/war-manifest-guide.apt.vm
@@ -66,7 +66,7 @@ WAR Manifest Customization
   Now, you can control which dependencies are included in <<<WEB-INF/lib>>> and in the manifest classpath by following
   these examples.  Maven will follow the transitive dependency tree until it gets to artifacts scoped as "provided".
 
-  <<Note:>> No way is shown how to include a dependency in <<<WEB-INF/lib>>> but not in the manifest classpath.
+  <<Note:>> No example is shown for including a dependency in <<<WEB-INF/lib>>> while excluding it from the manifest classpath.
 
 +--------------------+
 <project>

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -38,7 +38,7 @@ ${project.name}
    <<<package>>> phase for projects with a packaging type of <<<war>>>. 
    It builds a WAR file.
 
- * {{{./exploded-mojo.html}war:exploded}} is generally used to speed up 
+ * {{{./exploded-mojo.html}war:exploded}} speeds up 
    testing during the development phase by creating an exploded webapp 
    in a specified directory.
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -39,10 +39,10 @@ ${project.name}
    It builds a WAR file.
 
  * {{{./exploded-mojo.html}war:exploded}} is generally used to speed up 
-   testing during the developement phase by creating an exploded webapp 
+   testing during the development phase by creating an exploded webapp 
    in a specified directory.
 
- * {{{./inplace-mojo.html}war:inplace}} another variation of <<<war:explode>>> 
+ * {{{./inplace-mojo.html}war:inplace}} another variation of <<<war:exploded>>> 
    where the webapp is instead generated in the web application source directory, 
    which is <<<src/main/webapp>>> by default.
 

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -42,7 +42,7 @@ ${project.name}
    testing during the development phase by creating an exploded webapp 
    in a specified directory.
 
- * {{{./inplace-mojo.html}war:inplace}} another variation of <<<war:exploded>>> 
+  * {{{./inplace-mojo.html}war:inplace}} is another variation of <<<war:exploded>>> 
    where the webapp is instead generated in the web application source directory, 
    which is <<<src/main/webapp>>> by default.
 

--- a/src/site/apt/overlays.apt.vm
+++ b/src/site/apt/overlays.apt.vm
@@ -157,7 +157,7 @@ documentedprojectdependency-1.0-SNAPSHOT.war
   configure. Default value is: <<<war>>>.
 
   * <<classifier>> - the classifier of the overlay artifact you want to
-  configure if multiple artifacts matches the groupId/artifactId.
+  configure if multiple artifacts match the groupId/artifactId.
 
   * <<includes>> - the files to include. By default, all files are included.
 
@@ -256,7 +256,7 @@ documentedprojectdependency-1.0-SNAPSHOT.war
 
   To perform an even more fine grained overwriting policy, overlays can be packaged multiple times
   with different includes/excludes. For instance if the <<<index.jsp>>> file of the
-  overlay <<<my-webapp>>> <<must>> be set in the webapp but other files can be controlled the
+  overlay <<<my-webapp>>> <<must>> be set in the webapp but other files can be controlled in the
   regular way, define two overlay configurations for <<<my-webapp>>>:
 
 +-----------------+

--- a/src/site/apt/overlays.apt.vm
+++ b/src/site/apt/overlays.apt.vm
@@ -255,7 +255,7 @@ documentedprojectdependency-1.0-SNAPSHOT.war
   since they have not been configured in the <<<\<overlays\>>>> element.
 
   To perform an even more fine grained overwriting policy, overlays can be packaged multiple times
-  with different includes/excludes. For instance if the <<<index.jsp>>> file of the
+  with different includes/excludes. For example, if the <<<index.jsp>>> file of the
   overlay <<<my-webapp>>> <<must>> be set in the webapp but other files can be controlled in the
   regular way, define two overlay configurations for <<<my-webapp>>>:
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -129,7 +129,7 @@ documentedproject-1.0-SNAPSHOT.war
 
 *Invocation of <<<war:exploded>>> goal
 
-  To speed up testing during the development phase, <<<war:exploded>>> can be used to generate the WAR in exploded
+  To speed up testing during the development phase, <<<war:exploded>>> can generate the WAR in exploded
  form.
  Use the same project as above and invoke:
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -129,7 +129,7 @@ documentedproject-1.0-SNAPSHOT.war
 
 *Invocation of <<<war:exploded>>> goal
 
- To speed up testing during the development phase, <<<war:explode>>> can be used to generate the WAR in exploded
+  To speed up testing during the development phase, <<<war:exploded>>> can be used to generate the WAR in exploded
  form.
  Use the same project as above and invoke:
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -129,7 +129,7 @@ documentedproject-1.0-SNAPSHOT.war
 
 *Invocation of <<<war:exploded>>> goal
 
- To speed up testing during the developement phase, <<<war:explode>>> can be used to generate the WAR in exploded
+ To speed up testing during the development phase, <<<war:explode>>> can be used to generate the WAR in exploded
  form.
  Use the same project as above and invoke:
 


### PR DESCRIPTION
Fixes across 5 files:

Errors of fact:
- index.apt.vm: war:explode -> war:exploded (no such goal)
- rapid-testing-jetty6-plugin.apt: dead Codehaus link -> Eclipse Jetty docs

Typos:
- index.apt.vm: developement -> development
- usage.apt.vm: developement -> development

Grammar:
- overlays.apt.vm: artifacts matches -> artifacts match

Awkward phrasing:
- overlays.apt.vm: controlled the regular way -> controlled in the regular way
- war-manifest-guide.apt.vm: clarified note about dependency inclusion