### PR TITLE
[MWAR-471] normalize file permissions on dependencies copied to WEB-INF/lib

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -347,9 +347,11 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
                 // preserve timestamp
                 destination.setLastModified(readAttributes.lastModifiedTime().toMillis());
                 // normalize permissions: remove executable bits for files copied to the webapp
-                destination.setExecutable(false, false);
-                destination.setReadable(true, false);
-                destination.setWritable(true, true);
+                if (!destination.setExecutable(false, false)
+                        || !destination.setReadable(true, false)
+                        || !destination.setWritable(true, true)) {
+                    context.getLog().debug("Could not normalize permissions for " + targetFilename);
+                }
                 context.getLog().debug(" + " + targetFilename + " has been copied.");
             }
             return true;

--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -346,6 +346,10 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
                 FileUtils.copyFile(source.getCanonicalFile(), destination);
                 // preserve timestamp
                 destination.setLastModified(readAttributes.lastModifiedTime().toMillis());
+                // normalize permissions: remove executable bits for files copied to the webapp
+                destination.setExecutable(false, false);
+                destination.setReadable(true, false);
+                destination.setWritable(true, true);
                 context.getLog().debug(" + " + targetFilename + " has been copied.");
             }
             return true;

--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -346,10 +346,12 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
                 FileUtils.copyFile(source.getCanonicalFile(), destination);
                 // preserve timestamp
                 destination.setLastModified(readAttributes.lastModifiedTime().toMillis());
-                // normalize permissions: remove executable bits for files copied to the webapp
-                if (!destination.setExecutable(false, false)
-                        || !destination.setReadable(true, false)
-                        || !destination.setWritable(true, true)) {
+                // normalize permissions: clear executable, set read-for-all, write-for-owner
+                // on all copied files (not just WEB-INF/lib jars)
+                boolean ok = destination.setExecutable(false, false);
+                ok &= destination.setReadable(true, false);
+                ok &= destination.setWritable(true, true);
+                if (!ok) {
                     context.getLog().debug("Could not normalize permissions for " + targetFilename);
                 }
                 context.getLog().debug(" + " + targetFilename + " has been copied.");

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.war.packaging;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.war.util.WebappStructure;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.FilterWrapper;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AbstractWarPackagingTaskTest {
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    void testCopyFileRemovesExecutablePermissions() throws IOException {
+        File source = new File(tempDir, "source.jar");
+        assertTrue(source.createNewFile());
+        source.setExecutable(true, false);
+        source.setReadable(true, false);
+        source.setWritable(true, true);
+        assertTrue(source.canExecute());
+
+        File webappDir = new File(tempDir, "webapp");
+        File destination = new File(webappDir, "WEB-INF/lib/test.jar");
+
+        AbstractWarPackagingTask task = createTask();
+        task.copyFile(createContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
+
+        assertTrue(destination.exists());
+        assertFalse(destination.canExecute(), "copied file should not be executable");
+    }
+
+    @Test
+    void testCopyFileKeepsNonExecutable() throws IOException {
+        File source = new File(tempDir, "source.jar");
+        assertTrue(source.createNewFile());
+        source.setExecutable(false, false);
+        source.setReadable(true, false);
+        source.setWritable(true, true);
+        assertFalse(source.canExecute());
+
+        File webappDir = new File(tempDir, "webapp");
+        File destination = new File(webappDir, "WEB-INF/lib/test.jar");
+
+        AbstractWarPackagingTask task = createTask();
+        task.copyFile(createContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
+
+        assertTrue(destination.exists());
+        assertFalse(destination.canExecute(), "copied file should not be executable");
+    }
+
+    private static AbstractWarPackagingTask createTask() {
+        return new AbstractWarPackagingTask() {
+            @Override
+            public void performPackaging(WarPackagingContext context) {}
+        };
+    }
+
+    private static WarPackagingContext createContext(File webappDir) {
+        return new WarPackagingContext() {
+            @Override
+            public MavenProject getProject() {
+                return null;
+            }
+
+            @Override
+            public File getWebappDirectory() {
+                return webappDir;
+            }
+
+            @Override
+            public File getWebappSourceDirectory() {
+                return null;
+            }
+
+            @Override
+            public String[] getWebappSourceIncludes() {
+                return new String[0];
+            }
+
+            @Override
+            public boolean isWebappSourceIncludeEmptyDirectories() {
+                return false;
+            }
+
+            @Override
+            public String[] getWebappSourceExcludes() {
+                return new String[0];
+            }
+
+            @Override
+            public File getClassesDirectory() {
+                return null;
+            }
+
+            @Override
+            public boolean archiveClasses() {
+                return false;
+            }
+
+            @Override
+            public Log getLog() {
+                return new Log() {
+                    public void debug(CharSequence content) {}
+
+                    public void debug(Throwable content) {}
+
+                    public void debug(CharSequence content, Throwable error) {}
+
+                    public void info(CharSequence content) {}
+
+                    public void info(Throwable content) {}
+
+                    public void info(CharSequence content, Throwable error) {}
+
+                    public void warn(CharSequence content) {}
+
+                    public void warn(Throwable content) {}
+
+                    public void warn(CharSequence content, Throwable error) {}
+
+                    public void error(CharSequence content) {}
+
+                    public void error(Throwable content) {}
+
+                    public void error(CharSequence content, Throwable error) {}
+
+                    public boolean isDebugEnabled() {
+                        return false;
+                    }
+
+                    public boolean isInfoEnabled() {
+                        return false;
+                    }
+
+                    public boolean isWarnEnabled() {
+                        return false;
+                    }
+
+                    public boolean isErrorEnabled() {
+                        return false;
+                    }
+                };
+            }
+
+            @Override
+            public File getOverlaysWorkDirectory() {
+                return null;
+            }
+
+            @Override
+            public ArchiverManager getArchiverManager() {
+                return null;
+            }
+
+            @Override
+            public MavenArchiveConfiguration getArchive() {
+                return null;
+            }
+
+            @Override
+            public JarArchiver getJarArchiver() {
+                return null;
+            }
+
+            @Override
+            public String getOutputFileNameMapping() {
+                return null;
+            }
+
+            @Override
+            public List<String> getFilters() {
+                return null;
+            }
+
+            @Override
+            public WebappStructure getWebappStructure() {
+                return new WebappStructure(new ArrayList<>());
+            }
+
+            @Override
+            public List<String> getOwnerIds() {
+                return Collections.singletonList("test");
+            }
+
+            @Override
+            public MavenFileFilter getMavenFileFilter() {
+                return null;
+            }
+
+            @Override
+            public List<FilterWrapper> getFilterWrappers() {
+                return null;
+            }
+
+            @Override
+            public boolean isNonFilteredExtension(String fileName) {
+                return false;
+            }
+
+            @Override
+            public boolean isFilteringDeploymentDescriptors() {
+                return false;
+            }
+
+            @Override
+            public ArtifactHandlerManager getArtifactHandlerManager() {
+                return null;
+            }
+
+            @Override
+            public MavenSession getSession() {
+                return null;
+            }
+
+            @Override
+            public String getResourceEncoding() {
+                return null;
+            }
+
+            @Override
+            public String getPropertiesEncoding() {
+                return null;
+            }
+
+            @Override
+            public Boolean isFailOnMissingWebXml() {
+                return null;
+            }
+
+            @Override
+            public void addResource(String resource) {}
+
+            @Override
+            public void deleteOutdatedResources() {}
+
+            @Override
+            public String getOutputTimestamp() {
+                return null;
+            }
+
+            @Override
+            public List<String> getPackagingExcludes() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<String> getPackagingIncludes() {
+                return Collections.singletonList("**/**");
+            }
+        };
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -26,31 +26,16 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 class AbstractWarPackagingTaskTest {
-
-    private static final boolean POSIX_PERMISSIONS_SUPPORTED;
-
-    static {
-        boolean supported = false;
-        try {
-            File tmp = File.createTempFile("permtest", ".tmp");
-            try {
-                supported = tmp.setExecutable(false, false);
-            } finally {
-                tmp.delete();
-            }
-        } catch (IOException e) {
-            // not supported
-        }
-        POSIX_PERMISSIONS_SUPPORTED = supported;
-    }
 
     @TempDir
     File tempDir;
 
     @Test
     void testCopyFileRemovesExecutablePermissions() throws IOException {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("windows"));
         File source = new File(tempDir, "source.jar");
         assertTrue(source.createNewFile());
         source.setExecutable(true, false);
@@ -64,15 +49,14 @@ class AbstractWarPackagingTaskTest {
         task.copyFile(new TestWarPackagingContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
 
         assertTrue(destination.exists());
+        assertFalse(destination.canExecute(), "copied file should not be executable");
         assertTrue(destination.canRead(), "copied file should be readable");
         assertTrue(destination.canWrite(), "copied file should be writable");
-        if (POSIX_PERMISSIONS_SUPPORTED) {
-            assertFalse(destination.canExecute(), "copied file should not be executable");
-        }
     }
 
     @Test
     void testCopyFilePreservesNonExecutable() throws IOException {
+        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("windows"));
         File source = new File(tempDir, "source.jar");
         assertTrue(source.createNewFile());
         source.setExecutable(false, false);
@@ -86,11 +70,9 @@ class AbstractWarPackagingTaskTest {
         task.copyFile(new TestWarPackagingContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
 
         assertTrue(destination.exists());
+        assertFalse(destination.canExecute(), "copied file should not be executable");
         assertTrue(destination.canRead(), "copied file should be readable");
         assertTrue(destination.canWrite(), "copied file should be writable");
-        if (POSIX_PERMISSIONS_SUPPORTED) {
-            assertFalse(destination.canExecute(), "copied file should not be executable");
-        }
     }
 
     private static AbstractWarPackagingTask createTask() {

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -26,9 +26,25 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class AbstractWarPackagingTaskTest {
+
+    private static final boolean POSIX_PERMISSIONS_SUPPORTED;
+
+    static {
+        boolean supported = false;
+        try {
+            File tmp = File.createTempFile("permtest", ".tmp");
+            try {
+                supported = tmp.setExecutable(false, false);
+            } finally {
+                tmp.delete();
+            }
+        } catch (IOException e) {
+            // not supported
+        }
+        POSIX_PERMISSIONS_SUPPORTED = supported;
+    }
 
     @TempDir
     File tempDir;
@@ -40,7 +56,6 @@ class AbstractWarPackagingTaskTest {
         source.setExecutable(true, false);
         source.setReadable(true, false);
         source.setWritable(true, true);
-        assumeTrue(source.canExecute(), "test requires a platform that supports executable permission");
 
         File webappDir = new File(tempDir, "webapp");
         File destination = new File(webappDir, "WEB-INF/lib/test.jar");
@@ -49,9 +64,11 @@ class AbstractWarPackagingTaskTest {
         task.copyFile(new TestWarPackagingContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
 
         assertTrue(destination.exists());
-        assertFalse(destination.canExecute(), "copied file should not be executable");
         assertTrue(destination.canRead(), "copied file should be readable");
         assertTrue(destination.canWrite(), "copied file should be writable");
+        if (POSIX_PERMISSIONS_SUPPORTED) {
+            assertFalse(destination.canExecute(), "copied file should not be executable");
+        }
     }
 
     @Test
@@ -69,9 +86,11 @@ class AbstractWarPackagingTaskTest {
         task.copyFile(new TestWarPackagingContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
 
         assertTrue(destination.exists());
-        assertFalse(destination.canExecute(), "copied file should not be executable");
         assertTrue(destination.canRead(), "copied file should be readable");
         assertTrue(destination.canWrite(), "copied file should be writable");
+        if (POSIX_PERMISSIONS_SUPPORTED) {
+            assertFalse(destination.canExecute(), "copied file should not be executable");
+        }
     }
 
     private static AbstractWarPackagingTask createTask() {

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -50,6 +50,8 @@ class AbstractWarPackagingTaskTest {
 
         assertTrue(destination.exists());
         assertFalse(destination.canExecute(), "copied file should not be executable");
+        assertTrue(destination.canRead(), "copied file should be readable");
+        assertTrue(destination.canWrite(), "copied file should be writable");
     }
 
     @Test
@@ -68,6 +70,8 @@ class AbstractWarPackagingTaskTest {
 
         assertTrue(destination.exists());
         assertFalse(destination.canExecute(), "copied file should not be executable");
+        assertTrue(destination.canRead(), "copied file should be readable");
+        assertTrue(destination.canWrite(), "copied file should be writable");
     }
 
     private static AbstractWarPackagingTask createTask() {

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class AbstractWarPackagingTaskTest {
 
@@ -39,6 +40,7 @@ class AbstractWarPackagingTaskTest {
         source.setExecutable(true, false);
         source.setReadable(true, false);
         source.setWritable(true, true);
+        assumeTrue(source.canExecute(), "test requires a platform that supports executable permission");
 
         File webappDir = new File(tempDir, "webapp");
         File destination = new File(webappDir, "WEB-INF/lib/test.jar");
@@ -51,7 +53,7 @@ class AbstractWarPackagingTaskTest {
     }
 
     @Test
-    void testCopyFileKeepsNonExecutable() throws IOException {
+    void testCopyFilePreservesNonExecutable() throws IOException {
         File source = new File(tempDir, "source.jar");
         assertTrue(source.createNewFile());
         source.setExecutable(false, false);

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -20,20 +20,7 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
-import org.apache.maven.archiver.MavenArchiveConfiguration;
-import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.war.util.WebappStructure;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.filtering.FilterWrapper;
-import org.apache.maven.shared.filtering.MavenFileFilter;
-import org.codehaus.plexus.archiver.jar.JarArchiver;
-import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -52,13 +39,12 @@ class AbstractWarPackagingTaskTest {
         source.setExecutable(true, false);
         source.setReadable(true, false);
         source.setWritable(true, true);
-        assertTrue(source.canExecute());
 
         File webappDir = new File(tempDir, "webapp");
         File destination = new File(webappDir, "WEB-INF/lib/test.jar");
 
         AbstractWarPackagingTask task = createTask();
-        task.copyFile(createContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
+        task.copyFile(new TestWarPackagingContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
 
         assertTrue(destination.exists());
         assertFalse(destination.canExecute(), "copied file should not be executable");
@@ -71,13 +57,12 @@ class AbstractWarPackagingTaskTest {
         source.setExecutable(false, false);
         source.setReadable(true, false);
         source.setWritable(true, true);
-        assertFalse(source.canExecute());
 
         File webappDir = new File(tempDir, "webapp");
         File destination = new File(webappDir, "WEB-INF/lib/test.jar");
 
         AbstractWarPackagingTask task = createTask();
-        task.copyFile(createContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
+        task.copyFile(new TestWarPackagingContext(webappDir), source, destination, "WEB-INF/lib/test.jar", false);
 
         assertTrue(destination.exists());
         assertFalse(destination.canExecute(), "copied file should not be executable");
@@ -87,201 +72,6 @@ class AbstractWarPackagingTaskTest {
         return new AbstractWarPackagingTask() {
             @Override
             public void performPackaging(WarPackagingContext context) {}
-        };
-    }
-
-    private static WarPackagingContext createContext(File webappDir) {
-        return new WarPackagingContext() {
-            @Override
-            public MavenProject getProject() {
-                return null;
-            }
-
-            @Override
-            public File getWebappDirectory() {
-                return webappDir;
-            }
-
-            @Override
-            public File getWebappSourceDirectory() {
-                return null;
-            }
-
-            @Override
-            public String[] getWebappSourceIncludes() {
-                return new String[0];
-            }
-
-            @Override
-            public boolean isWebappSourceIncludeEmptyDirectories() {
-                return false;
-            }
-
-            @Override
-            public String[] getWebappSourceExcludes() {
-                return new String[0];
-            }
-
-            @Override
-            public File getClassesDirectory() {
-                return null;
-            }
-
-            @Override
-            public boolean archiveClasses() {
-                return false;
-            }
-
-            @Override
-            public Log getLog() {
-                return new Log() {
-                    public void debug(CharSequence content) {}
-
-                    public void debug(Throwable content) {}
-
-                    public void debug(CharSequence content, Throwable error) {}
-
-                    public void info(CharSequence content) {}
-
-                    public void info(Throwable content) {}
-
-                    public void info(CharSequence content, Throwable error) {}
-
-                    public void warn(CharSequence content) {}
-
-                    public void warn(Throwable content) {}
-
-                    public void warn(CharSequence content, Throwable error) {}
-
-                    public void error(CharSequence content) {}
-
-                    public void error(Throwable content) {}
-
-                    public void error(CharSequence content, Throwable error) {}
-
-                    public boolean isDebugEnabled() {
-                        return false;
-                    }
-
-                    public boolean isInfoEnabled() {
-                        return false;
-                    }
-
-                    public boolean isWarnEnabled() {
-                        return false;
-                    }
-
-                    public boolean isErrorEnabled() {
-                        return false;
-                    }
-                };
-            }
-
-            @Override
-            public File getOverlaysWorkDirectory() {
-                return null;
-            }
-
-            @Override
-            public ArchiverManager getArchiverManager() {
-                return null;
-            }
-
-            @Override
-            public MavenArchiveConfiguration getArchive() {
-                return null;
-            }
-
-            @Override
-            public JarArchiver getJarArchiver() {
-                return null;
-            }
-
-            @Override
-            public String getOutputFileNameMapping() {
-                return null;
-            }
-
-            @Override
-            public List<String> getFilters() {
-                return null;
-            }
-
-            @Override
-            public WebappStructure getWebappStructure() {
-                return new WebappStructure(new ArrayList<>());
-            }
-
-            @Override
-            public List<String> getOwnerIds() {
-                return Collections.singletonList("test");
-            }
-
-            @Override
-            public MavenFileFilter getMavenFileFilter() {
-                return null;
-            }
-
-            @Override
-            public List<FilterWrapper> getFilterWrappers() {
-                return null;
-            }
-
-            @Override
-            public boolean isNonFilteredExtension(String fileName) {
-                return false;
-            }
-
-            @Override
-            public boolean isFilteringDeploymentDescriptors() {
-                return false;
-            }
-
-            @Override
-            public ArtifactHandlerManager getArtifactHandlerManager() {
-                return null;
-            }
-
-            @Override
-            public MavenSession getSession() {
-                return null;
-            }
-
-            @Override
-            public String getResourceEncoding() {
-                return null;
-            }
-
-            @Override
-            public String getPropertiesEncoding() {
-                return null;
-            }
-
-            @Override
-            public Boolean isFailOnMissingWebXml() {
-                return null;
-            }
-
-            @Override
-            public void addResource(String resource) {}
-
-            @Override
-            public void deleteOutdatedResources() {}
-
-            @Override
-            public String getOutputTimestamp() {
-                return null;
-            }
-
-            @Override
-            public List<String> getPackagingExcludes() {
-                return Collections.emptyList();
-            }
-
-            @Override
-            public List<String> getPackagingIncludes() {
-                return Collections.singletonList("**/**");
-            }
         };
     }
 }

--- a/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTaskTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -33,9 +34,16 @@ class AbstractWarPackagingTaskTest {
     @TempDir
     File tempDir;
 
+    // Windows does not support POSIX executable permissions, so canExecute()
+    // may return true regardless of setExecutable(). These tests verify
+    // permission normalization which is only meaningful on POSIX systems.
+    private static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows");
+    }
+
     @Test
     void testCopyFileRemovesExecutablePermissions() throws IOException {
-        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("windows"));
+        assumeFalse(isWindows());
         File source = new File(tempDir, "source.jar");
         assertTrue(source.createNewFile());
         source.setExecutable(true, false);
@@ -56,7 +64,7 @@ class AbstractWarPackagingTaskTest {
 
     @Test
     void testCopyFilePreservesNonExecutable() throws IOException {
-        assumeFalse(System.getProperty("os.name").toLowerCase().startsWith("windows"));
+        assumeFalse(isWindows());
         File source = new File(tempDir, "source.jar");
         assertTrue(source.createNewFile());
         source.setExecutable(false, false);

--- a/src/test/java/org/apache/maven/plugins/war/packaging/TestWarPackagingContext.java
+++ b/src/test/java/org/apache/maven/plugins/war/packaging/TestWarPackagingContext.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.war.packaging;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.archiver.MavenArchiveConfiguration;
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.war.util.WebappStructure;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.FilterWrapper;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+
+class TestWarPackagingContext implements WarPackagingContext {
+
+    private final File webappDir;
+
+    TestWarPackagingContext(File webappDir) {
+        this.webappDir = webappDir;
+    }
+
+    @Override
+    public MavenProject getProject() {
+        return null;
+    }
+
+    @Override
+    public File getWebappDirectory() {
+        return webappDir;
+    }
+
+    @Override
+    public File getWebappSourceDirectory() {
+        return null;
+    }
+
+    @Override
+    public String[] getWebappSourceIncludes() {
+        return new String[0];
+    }
+
+    @Override
+    public boolean isWebappSourceIncludeEmptyDirectories() {
+        return false;
+    }
+
+    @Override
+    public String[] getWebappSourceExcludes() {
+        return new String[0];
+    }
+
+    @Override
+    public File getClassesDirectory() {
+        return null;
+    }
+
+    @Override
+    public boolean archiveClasses() {
+        return false;
+    }
+
+    @Override
+    public Log getLog() {
+        return new Log() {
+            public void debug(CharSequence content) {}
+
+            public void debug(Throwable content) {}
+
+            public void debug(CharSequence content, Throwable error) {}
+
+            public void info(CharSequence content) {}
+
+            public void info(Throwable content) {}
+
+            public void info(CharSequence content, Throwable error) {}
+
+            public void warn(CharSequence content) {}
+
+            public void warn(Throwable content) {}
+
+            public void warn(CharSequence content, Throwable error) {}
+
+            public void error(CharSequence content) {}
+
+            public void error(Throwable content) {}
+
+            public void error(CharSequence content, Throwable error) {}
+
+            public boolean isDebugEnabled() {
+                return false;
+            }
+
+            public boolean isInfoEnabled() {
+                return false;
+            }
+
+            public boolean isWarnEnabled() {
+                return false;
+            }
+
+            public boolean isErrorEnabled() {
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public File getOverlaysWorkDirectory() {
+        return null;
+    }
+
+    @Override
+    public ArchiverManager getArchiverManager() {
+        return null;
+    }
+
+    @Override
+    public MavenArchiveConfiguration getArchive() {
+        return null;
+    }
+
+    @Override
+    public JarArchiver getJarArchiver() {
+        return null;
+    }
+
+    @Override
+    public String getOutputFileNameMapping() {
+        return null;
+    }
+
+    @Override
+    public List<String> getFilters() {
+        return null;
+    }
+
+    @Override
+    public WebappStructure getWebappStructure() {
+        return new WebappStructure(new ArrayList<>());
+    }
+
+    @Override
+    public List<String> getOwnerIds() {
+        return Collections.singletonList("test");
+    }
+
+    @Override
+    public MavenFileFilter getMavenFileFilter() {
+        return null;
+    }
+
+    @Override
+    public List<FilterWrapper> getFilterWrappers() {
+        return null;
+    }
+
+    @Override
+    public boolean isNonFilteredExtension(String fileName) {
+        return false;
+    }
+
+    @Override
+    public boolean isFilteringDeploymentDescriptors() {
+        return false;
+    }
+
+    @Override
+    public ArtifactHandlerManager getArtifactHandlerManager() {
+        return null;
+    }
+
+    @Override
+    public MavenSession getSession() {
+        return null;
+    }
+
+    @Override
+    public String getResourceEncoding() {
+        return null;
+    }
+
+    @Override
+    public String getPropertiesEncoding() {
+        return null;
+    }
+
+    @Override
+    public Boolean isFailOnMissingWebXml() {
+        return null;
+    }
+
+    @Override
+    public void addResource(String resource) {}
+
+    @Override
+    public void deleteOutdatedResources() {}
+
+    @Override
+    public String getOutputTimestamp() {
+        return null;
+    }
+
+    @Override
+    public List<String> getPackagingExcludes() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getPackagingIncludes() {
+        return Collections.singletonList("**/**");
+    }
+}


### PR DESCRIPTION
When building on Windows with WSL sharing a disk with the local repository, dependency jars copied to WEB-INF/lib may inherit executable permissions from the local repository.

This normalizes file permissions on copied files to:
- Not executable
- Readable by everyone
- Writable only by owner

Fixes #539