### PR TITLE
Replace deprecated XmlStreamReader(File) with XmlStreamReader(InputStream)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -360,7 +360,8 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
      * @throws java.io.IOException if an error occurred while reading the file
      */
     protected String getEncoding(File webXml) throws IOException {
-        try (XmlStreamReader xmlReader = XmlStreamReader.builder().setFile(webXml).get()) {
+        try (XmlStreamReader xmlReader =
+                XmlStreamReader.builder().setFile(webXml).get()) {
             return xmlReader.getEncoding();
         }
     }

--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
@@ -360,7 +361,8 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
      * @throws java.io.IOException if an error occurred while reading the file
      */
     protected String getEncoding(File webXml) throws IOException {
-        try (XmlStreamReader xmlReader = new XmlStreamReader(Files.newInputStream(webXml.toPath()))) {
+        try (InputStream in = Files.newInputStream(webXml.toPath());
+                XmlStreamReader xmlReader = new XmlStreamReader(in)) {
             return xmlReader.getEncoding();
         }
     }

--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -360,7 +360,7 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
      * @throws java.io.IOException if an error occurred while reading the file
      */
     protected String getEncoding(File webXml) throws IOException {
-        try (XmlStreamReader xmlReader = new XmlStreamReader(webXml)) {
+        try (XmlStreamReader xmlReader = new XmlStreamReader(Files.newInputStream(webXml.toPath()))) {
             return xmlReader.getEncoding();
         }
     }

--- a/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/AbstractWarPackagingTask.java
@@ -20,7 +20,6 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
@@ -361,8 +360,7 @@ public abstract class AbstractWarPackagingTask implements WarPackagingTask {
      * @throws java.io.IOException if an error occurred while reading the file
      */
     protected String getEncoding(File webXml) throws IOException {
-        try (InputStream in = Files.newInputStream(webXml.toPath());
-                XmlStreamReader xmlReader = new XmlStreamReader(in)) {
+        try (XmlStreamReader xmlReader = XmlStreamReader.builder().setFile(webXml).get()) {
             return xmlReader.getEncoding();
         }
     }


### PR DESCRIPTION
The XmlStreamReader(File) constructor is deprecated in commons-io. Replaced with XmlStreamReader(InputStream) using Files.newInputStream(Path) which is the recommended replacement.

- No functional change