### PR TITLE
[MWAR-220] Add integration test for overlay dependencyManagement version conflict

### DIFF
--- a/src/it/MWAR-389/invoker.properties
+++ b/src/it/MWAR-389/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean install
+# This test is expected to fail until MWAR-220 is fixed.
+# When the fix is implemented, remove this line.
+invoker.failureExpected=true

--- a/src/it/MWAR-389/invoker.properties
+++ b/src/it/MWAR-389/invoker.properties
@@ -16,6 +16,3 @@
 # under the License.
 
 invoker.goals=clean install
-# This test is expected to fail until MWAR-220 is fixed.
-# When the fix is implemented, remove this line.
-invoker.failureExpected=true

--- a/src/it/MWAR-389/main-war/pom.xml
+++ b/src/it/MWAR-389/main-war/pom.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>MWAR-389</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>main-war</artifactId>
+  <packaging>war</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>@plexusUtilVersion@</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>overlay-war</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>war</type>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+  version="3.0">
+</web-app>

--- a/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-  version="3.0">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
 </web-app>

--- a/src/it/MWAR-389/overlay-war/pom.xml
+++ b/src/it/MWAR-389/overlay-war/pom.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>MWAR-389</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>overlay-war</artifactId>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+  version="3.0">
+</web-app>

--- a/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-  version="3.0">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
 </web-app>

--- a/src/it/MWAR-389/pom.xml
+++ b/src/it/MWAR-389/pom.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>MWAR-389</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>MWAR-389 dependencyManagement overlay dependency version conflict</name>
+  <modules>
+    <module>overlay-war</module>
+    <module>main-war</module>
+  </modules>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/MWAR-389/verify.bsh
+++ b/src/it/MWAR-389/verify.bsh
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+/*
+ * Test for MWAR-220 / issue #389:
+ * dependencyManagement with overlays should not result in multiple versions
+ * of the same dependency in WEB-INF/lib.
+ *
+ * The overlay-war is built with plexus-utils 3.0.24.
+ * The main-war has dependencyManagement pinning plexus-utils to the managed
+ * version (@plexusUtilVersion@), and uses overlay-war as an overlay.
+ *
+ * If the issue still exists, both versions will appear in main-war's WEB-INF/lib.
+ * If fixed, only the managed version will appear.
+ */
+
+String managedVersion = plexusUtilVersion;
+
+// --- Check overlay WAR content ---
+File overlayTarget = new File( basedir, "overlay-war/target" );
+File overlayWar = new File( overlayTarget, "overlay-war-1.0-SNAPSHOT" );
+File overlayLib = new File( overlayWar, "WEB-INF/lib" );
+
+String[] overlayJars = overlayLib.list();
+boolean overlayHasOld = false;
+boolean overlayHasManaged = false;
+
+for ( int i = 0; i < overlayJars.length; i++ )
+{
+    String jar = overlayJars[i];
+    if ( jar.startsWith( "plexus-utils-3.0.24" ) )
+    {
+        overlayHasOld = true;
+    }
+    if ( jar.startsWith( "plexus-utils-" + managedVersion ) )
+    {
+        overlayHasManaged = true;
+    }
+}
+
+if ( !overlayHasOld )
+{
+    System.err.println( "Overlay WAR missing plexus-utils-3.0.24.jar in WEB-INF/lib." );
+    return false;
+}
+
+if ( overlayHasManaged )
+{
+    System.err.println( "Overlay WAR unexpectedly contains plexus-utils-" + managedVersion + ".jar. "
+        + "Overlay should only have version 3.0.24." );
+    return false;
+}
+
+System.out.println( "Overlay WAR correctly contains only plexus-utils-3.0.24.jar." );
+
+// --- Check main WAR content ---
+File mainTarget = new File( basedir, "main-war/target" );
+File mainWar = new File( mainTarget, "main-war-1.0-SNAPSHOT" );
+File mainLib = new File( mainWar, "WEB-INF/lib" );
+
+String[] mainJars = mainLib.list();
+boolean mainHasOld = false;
+boolean mainHasManaged = false;
+List duplicateGavs = new ArrayList();
+
+for ( int i = 0; i < mainJars.length; i++ )
+{
+    String jar = mainJars[i];
+    if ( jar.startsWith( "plexus-utils-3.0.24" ) )
+    {
+        mainHasOld = true;
+        duplicateGavs.add( "plexus-utils:3.0.24 (" + jar + ")" );
+    }
+    if ( jar.startsWith( "plexus-utils-" + managedVersion ) )
+    {
+        mainHasManaged = true;
+        duplicateGavs.add( "plexus-utils:" + managedVersion + " (" + jar + ")" );
+    }
+}
+
+if ( !mainHasManaged )
+{
+    System.err.println( "Main WAR missing plexus-utils-" + managedVersion + ".jar in WEB-INF/lib." );
+    return false;
+}
+
+if ( mainHasOld )
+{
+    // Both versions found -- issue STILL EXISTS
+    System.out.println( "ISSUE #389 (MWAR-220) STILL EXISTS:" );
+    System.out.println( "  Both plexus-utils versions found in main WAR WEB-INF/lib:" );
+    System.out.println( "    - plexus-utils-3.0.24.jar (from overlay unpacking)" );
+    System.out.println( "    - plexus-utils-" + managedVersion + ".jar (from dependencyManagement)" );
+    System.out.println( "  dependencyManagement does not filter overlay-provided jars." );
+    return false;
+}
+else
+{
+    // Only managed version -- issue has been fixed
+    System.out.println( "ISSUE #389 (MWAR-220) APPEARS FIXED:" );
+    System.out.println( "  Only plexus-utils-" + managedVersion + ".jar found in WEB-INF/lib." );
+    System.out.println( "  The overlay's plexus-utils-3.0.24.jar was correctly filtered out." );
+    return true;
+}

--- a/src/it/MWAR-389/verify.bsh
+++ b/src/it/MWAR-389/verify.bsh
@@ -18,7 +18,6 @@
  */
 
 import java.io.*;
-import java.util.*;
 import org.codehaus.plexus.util.*;
 
 /*
@@ -71,7 +70,7 @@ if ( overlayHasManaged )
     return false;
 }
 
-System.out.println( "Overlay WAR correctly contains only plexus-utils-3.0.24.jar." );
+// Overlay WAR correctly contains only plexus-utils-3.0.24.jar.
 
 // --- Check main WAR content ---
 File mainTarget = new File( basedir, "main-war/target" );
@@ -81,7 +80,6 @@ File mainLib = new File( mainWar, "WEB-INF/lib" );
 String[] mainJars = mainLib.list();
 boolean mainHasOld = false;
 boolean mainHasManaged = false;
-List duplicateGavs = new ArrayList();
 
 for ( int i = 0; i < mainJars.length; i++ )
 {
@@ -89,12 +87,10 @@ for ( int i = 0; i < mainJars.length; i++ )
     if ( jar.startsWith( "plexus-utils-3.0.24" ) )
     {
         mainHasOld = true;
-        duplicateGavs.add( "plexus-utils:3.0.24 (" + jar + ")" );
     }
     if ( jar.startsWith( "plexus-utils-" + managedVersion ) )
     {
         mainHasManaged = true;
-        duplicateGavs.add( "plexus-utils:" + managedVersion + " (" + jar + ")" );
     }
 }
 
@@ -107,18 +103,12 @@ if ( !mainHasManaged )
 if ( mainHasOld )
 {
     // Both versions found -- issue STILL EXISTS
-    System.out.println( "ISSUE #389 (MWAR-220) STILL EXISTS:" );
-    System.out.println( "  Both plexus-utils versions found in main WAR WEB-INF/lib:" );
-    System.out.println( "    - plexus-utils-3.0.24.jar (from overlay unpacking)" );
-    System.out.println( "    - plexus-utils-" + managedVersion + ".jar (from dependencyManagement)" );
-    System.out.println( "  dependencyManagement does not filter overlay-provided jars." );
+    System.err.println( "Found plexus-utils-3.0.24.jar in main WAR WEB-INF/lib; "
+        + "dependencyManagement should have excluded it." );
     return false;
 }
 else
 {
     // Only managed version -- issue has been fixed
-    System.out.println( "ISSUE #389 (MWAR-220) APPEARS FIXED:" );
-    System.out.println( "  Only plexus-utils-" + managedVersion + ".jar found in WEB-INF/lib." );
-    System.out.println( "  The overlay's plexus-utils-3.0.24.jar was correctly filtered out." );
     return true;
 }


### PR DESCRIPTION
## Integration test for MWAR-220 / issue #389

Adds an integration test that reproduces the issue where dependencyManagement does not filter conflicting dependency versions pulled in by WAR overlays.

### Test setup
- `overlay-war` depends on `plexus-utils:3.0.24`
- `main-war` has dependencyManagement pinning `plexus-utils` to @plexusUtilVersion@ (4.0.3) and uses `overlay-war` as an overlay

### Expected result (current)
Both `plexus-utils-3.0.24.jar` (from overlay unpacking) and `plexus-utils-4.0.3.jar` (from dependencyManagement) appear in the final WAR's `WEB-INF/lib`.

### Desired behavior
Only the dependencyManagement-pinned version (`plexus-utils-4.0.3.jar`) should appear.

This test is expected to fail on CI — it documents the known issue. A subsequent fix should make it pass.