### PR TITLE
[MWAR-220] filter overlay jars conflicting with managed dependencies

### DIFF
--- a/src/it/MWAR-389/invoker.properties
+++ b/src/it/MWAR-389/invoker.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals=clean install
+# This test is expected to fail until MWAR-220 is fixed.
+# When the fix is implemented, remove this line.
+invoker.failureExpected=true

--- a/src/it/MWAR-389/invoker.properties
+++ b/src/it/MWAR-389/invoker.properties
@@ -16,6 +16,3 @@
 # under the License.
 
 invoker.goals=clean install
-# This test is expected to fail until MWAR-220 is fixed.
-# When the fix is implemented, remove this line.
-invoker.failureExpected=true

--- a/src/it/MWAR-389/main-war/pom.xml
+++ b/src/it/MWAR-389/main-war/pom.xml
@@ -1,0 +1,54 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>MWAR-389</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>main-war</artifactId>
+  <packaging>war</packaging>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>@plexusUtilVersion@</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>test</groupId>
+      <artifactId>overlay-war</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>war</type>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+  version="3.0">
+</web-app>

--- a/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/main-war/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-  version="3.0">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
 </web-app>

--- a/src/it/MWAR-389/overlay-war/pom.xml
+++ b/src/it/MWAR-389/overlay-war/pom.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>test</groupId>
+    <artifactId>MWAR-389</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>overlay-war</artifactId>
+  <packaging>war</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>3.0.24</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+  version="3.0">
+</web-app>

--- a/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
+++ b/src/it/MWAR-389/overlay-war/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,24 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-  version="3.0">
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<web-app xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd"
+         version="2.4">
 </web-app>

--- a/src/it/MWAR-389/pom.xml
+++ b/src/it/MWAR-389/pom.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>test</groupId>
+  <artifactId>MWAR-389</artifactId>
+  <packaging>pom</packaging>
+  <version>1.0-SNAPSHOT</version>
+  <name>MWAR-389 dependencyManagement overlay dependency version conflict</name>
+  <modules>
+    <module>overlay-war</module>
+    <module>main-war</module>
+  </modules>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>@pom.version@</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/MWAR-389/verify.bsh
+++ b/src/it/MWAR-389/verify.bsh
@@ -40,7 +40,18 @@ File overlayTarget = new File( basedir, "overlay-war/target" );
 File overlayWar = new File( overlayTarget, "overlay-war-1.0-SNAPSHOT" );
 File overlayLib = new File( overlayWar, "WEB-INF/lib" );
 
+if ( !overlayLib.exists() || !overlayLib.isDirectory() )
+{
+    System.err.println( "Overlay WAR WEB-INF/lib directory missing: " + overlayLib );
+    return false;
+}
+
 String[] overlayJars = overlayLib.list();
+if ( overlayJars == null )
+{
+    System.err.println( "Failed to list overlay WAR WEB-INF/lib contents: " + overlayLib );
+    return false;
+}
 boolean overlayHasOld = false;
 boolean overlayHasManaged = false;
 

--- a/src/it/MWAR-389/verify.bsh
+++ b/src/it/MWAR-389/verify.bsh
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import java.util.*;
+import org.codehaus.plexus.util.*;
+
+/*
+ * Test for MWAR-220 / issue #389:
+ * dependencyManagement with overlays should not result in multiple versions
+ * of the same dependency in WEB-INF/lib.
+ *
+ * The overlay-war is built with plexus-utils 3.0.24.
+ * The main-war has dependencyManagement pinning plexus-utils to the managed
+ * version (@plexusUtilVersion@), and uses overlay-war as an overlay.
+ *
+ * If the issue still exists, both versions will appear in main-war's WEB-INF/lib.
+ * If fixed, only the managed version will appear.
+ */
+
+String managedVersion = plexusUtilVersion;
+
+// --- Check overlay WAR content ---
+File overlayTarget = new File( basedir, "overlay-war/target" );
+File overlayWar = new File( overlayTarget, "overlay-war-1.0-SNAPSHOT" );
+File overlayLib = new File( overlayWar, "WEB-INF/lib" );
+
+String[] overlayJars = overlayLib.list();
+boolean overlayHasOld = false;
+boolean overlayHasManaged = false;
+
+for ( int i = 0; i < overlayJars.length; i++ )
+{
+    String jar = overlayJars[i];
+    if ( jar.startsWith( "plexus-utils-3.0.24" ) )
+    {
+        overlayHasOld = true;
+    }
+    if ( jar.startsWith( "plexus-utils-" + managedVersion ) )
+    {
+        overlayHasManaged = true;
+    }
+}
+
+if ( !overlayHasOld )
+{
+    System.err.println( "Overlay WAR missing plexus-utils-3.0.24.jar in WEB-INF/lib." );
+    return false;
+}
+
+if ( overlayHasManaged )
+{
+    System.err.println( "Overlay WAR unexpectedly contains plexus-utils-" + managedVersion + ".jar. "
+        + "Overlay should only have version 3.0.24." );
+    return false;
+}
+
+System.out.println( "Overlay WAR correctly contains only plexus-utils-3.0.24.jar." );
+
+// --- Check main WAR content ---
+File mainTarget = new File( basedir, "main-war/target" );
+File mainWar = new File( mainTarget, "main-war-1.0-SNAPSHOT" );
+File mainLib = new File( mainWar, "WEB-INF/lib" );
+
+String[] mainJars = mainLib.list();
+boolean mainHasOld = false;
+boolean mainHasManaged = false;
+List duplicateGavs = new ArrayList();
+
+for ( int i = 0; i < mainJars.length; i++ )
+{
+    String jar = mainJars[i];
+    if ( jar.startsWith( "plexus-utils-3.0.24" ) )
+    {
+        mainHasOld = true;
+        duplicateGavs.add( "plexus-utils:3.0.24 (" + jar + ")" );
+    }
+    if ( jar.startsWith( "plexus-utils-" + managedVersion ) )
+    {
+        mainHasManaged = true;
+        duplicateGavs.add( "plexus-utils:" + managedVersion + " (" + jar + ")" );
+    }
+}
+
+if ( !mainHasManaged )
+{
+    System.err.println( "Main WAR missing plexus-utils-" + managedVersion + ".jar in WEB-INF/lib." );
+    return false;
+}
+
+if ( mainHasOld )
+{
+    // Both versions found -- issue STILL EXISTS
+    System.out.println( "ISSUE #389 (MWAR-220) STILL EXISTS:" );
+    System.out.println( "  Both plexus-utils versions found in main WAR WEB-INF/lib:" );
+    System.out.println( "    - plexus-utils-3.0.24.jar (from overlay unpacking)" );
+    System.out.println( "    - plexus-utils-" + managedVersion + ".jar (from dependencyManagement)" );
+    System.out.println( "  dependencyManagement does not filter overlay-provided jars." );
+    return false;
+}
+else
+{
+    // Only managed version -- issue has been fixed
+    System.out.println( "ISSUE #389 (MWAR-220) APPEARS FIXED:" );
+    System.out.println( "  Only plexus-utils-" + managedVersion + ".jar found in WEB-INF/lib." );
+    System.out.println( "  The overlay's plexus-utils-3.0.24.jar was correctly filtered out." );
+    return true;
+}

--- a/src/it/MWAR-389/verify.bsh
+++ b/src/it/MWAR-389/verify.bsh
@@ -18,7 +18,6 @@
  */
 
 import java.io.*;
-import java.util.*;
 import org.codehaus.plexus.util.*;
 
 /*
@@ -71,7 +70,7 @@ if ( overlayHasManaged )
     return false;
 }
 
-System.out.println( "Overlay WAR correctly contains only plexus-utils-3.0.24.jar." );
+// Overlay WAR correctly contains only plexus-utils-3.0.24.jar.
 
 // --- Check main WAR content ---
 File mainTarget = new File( basedir, "main-war/target" );
@@ -81,7 +80,6 @@ File mainLib = new File( mainWar, "WEB-INF/lib" );
 String[] mainJars = mainLib.list();
 boolean mainHasOld = false;
 boolean mainHasManaged = false;
-List duplicateGavs = new ArrayList();
 
 for ( int i = 0; i < mainJars.length; i++ )
 {
@@ -89,12 +87,10 @@ for ( int i = 0; i < mainJars.length; i++ )
     if ( jar.startsWith( "plexus-utils-3.0.24" ) )
     {
         mainHasOld = true;
-        duplicateGavs.add( "plexus-utils:3.0.24 (" + jar + ")" );
     }
     if ( jar.startsWith( "plexus-utils-" + managedVersion ) )
     {
         mainHasManaged = true;
-        duplicateGavs.add( "plexus-utils:" + managedVersion + " (" + jar + ")" );
     }
 }
 
@@ -107,18 +103,12 @@ if ( !mainHasManaged )
 if ( mainHasOld )
 {
     // Both versions found -- issue STILL EXISTS
-    System.out.println( "ISSUE #389 (MWAR-220) STILL EXISTS:" );
-    System.out.println( "  Both plexus-utils versions found in main WAR WEB-INF/lib:" );
-    System.out.println( "    - plexus-utils-3.0.24.jar (from overlay unpacking)" );
-    System.out.println( "    - plexus-utils-" + managedVersion + ".jar (from dependencyManagement)" );
-    System.out.println( "  dependencyManagement does not filter overlay-provided jars." );
+    System.err.println( "Found plexus-utils-3.0.24.jar in main WAR WEB-INF/lib; "
+        + "dependencyManagement should have excluded it." );
     return false;
 }
 else
 {
     // Only managed version -- issue has been fixed
-    System.out.println( "ISSUE #389 (MWAR-220) APPEARS FIXED:" );
-    System.out.println( "  Only plexus-utils-" + managedVersion + ".jar found in WEB-INF/lib." );
-    System.out.println( "  The overlay's plexus-utils-3.0.24.jar was correctly filtered out." );
     return true;
 }

--- a/src/it/MWAR-389/verify.bsh
+++ b/src/it/MWAR-389/verify.bsh
@@ -88,7 +88,18 @@ File mainTarget = new File( basedir, "main-war/target" );
 File mainWar = new File( mainTarget, "main-war-1.0-SNAPSHOT" );
 File mainLib = new File( mainWar, "WEB-INF/lib" );
 
+if ( !mainLib.exists() || !mainLib.isDirectory() )
+{
+    System.err.println( "Main WAR WEB-INF/lib directory missing: " + mainLib );
+    return false;
+}
+
 String[] mainJars = mainLib.list();
+if ( mainJars == null )
+{
+    System.err.println( "Failed to list main WAR WEB-INF/lib contents: " + mainLib );
+    return false;
+}
 boolean mainHasOld = false;
 boolean mainHasManaged = false;
 

--- a/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
@@ -20,7 +20,10 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.war.Overlay;
 import org.apache.maven.plugins.war.util.PathSet;
@@ -60,6 +63,9 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
 
                 // Step1: Extract if necessary
                 final File tmpDir = unpackOverlay(context, overlay);
+
+                // Step1b: Remove jars from overlay that conflict with managed dependencies
+                filterConflictingDependencyJars(context, tmpDir);
 
                 // Step2: setup
                 final PathSet includes = getFilesToIncludes(tmpDir, overlay.getIncludes(), overlay.getExcludes());
@@ -126,5 +132,73 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
             result.mkdirs();
         }
         return result;
+    }
+
+    /**
+     * Removes jars from the overlay's {@code WEB-INF/lib} that conflict with the project's managed
+     * dependencies. When a project uses dependencyManagement to pin a version, any jar from the
+     * overlay with the same artifactId but a different version is removed, ensuring only the
+     * dependency-managed version ends up in {@code WEB-INF/lib}.
+     *
+     * @param context the packaging context
+     * @param overlayDir the unpacked overlay directory
+     */
+    private void filterConflictingDependencyJars(WarPackagingContext context, File overlayDir) {
+        File libDir = new File(overlayDir, "WEB-INF/lib");
+        if (!libDir.isDirectory()) {
+            return;
+        }
+
+        Set<String> projectArtifactIds = new HashSet<>();
+        for (Artifact artifact : context.getProject().getArtifacts()) {
+            if (!artifact.isOptional() && "jar".equals(artifact.getType())) {
+                projectArtifactIds.add(artifact.getArtifactId());
+            }
+        }
+
+        if (projectArtifactIds.isEmpty()) {
+            return;
+        }
+
+        File[] overlayJars = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
+        if (overlayJars == null) {
+            return;
+        }
+
+        for (File overlayJar : overlayJars) {
+            String jarName = overlayJar.getName();
+            String artifactId = extractArtifactId(jarName);
+            if (artifactId != null && projectArtifactIds.contains(artifactId)) {
+                context.getLog()
+                        .debug("Removing dependency [" + jarName + "] from overlay [" + overlay.getId()
+                                + "]; managed version in project already provides it");
+                overlayJar.delete();
+            }
+        }
+    }
+
+    /**
+     * Extracts the Maven artifactId from a jar filename following the
+     * {@code artifactId-version(-classifier)?.jar} convention.
+     *
+     * @param jarName the jar filename
+     * @return the artifactId, or null if it cannot be determined
+     */
+    private static String extractArtifactId(String jarName) {
+        if (jarName == null || !jarName.endsWith(".jar")) {
+            return null;
+        }
+        String baseName = jarName.substring(0, jarName.length() - 4);
+        int versionStart = -1;
+        for (int i = 0; i < baseName.length(); i++) {
+            if (Character.isDigit(baseName.charAt(i))) {
+                versionStart = i;
+                break;
+            }
+        }
+        if (versionStart > 0 && baseName.charAt(versionStart - 1) == '-') {
+            return baseName.substring(0, versionStart - 1);
+        }
+        return null;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
@@ -20,10 +20,15 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.Properties;
 import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
@@ -139,9 +144,10 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
     }
 
     /**
-     * Identifies jars from the overlay's {@code WEB-INF/lib} whose artifactId matches a non-optional
-     * runtime-scope dependency resolved by the project. These jars are candidates for exclusion
-     * from the overlay copy so that only the project-resolved version ends up in {@code WEB-INF/lib}.
+     * Identifies jars from the overlay's {@code WEB-INF/lib} whose groupId:artifactId matches a
+     * non-optional runtime-scope dependency resolved by the project. When the overlay jar contains
+     * {@code META-INF/maven/**\/pom.properties}, the groupId is read from that metadata for a precise
+     * match. Otherwise, matching falls back to artifactId only.
      *
      * <p>The overlay's cached unpack directory is <em>not</em> mutated; the returned set is used
      * as additional excludes during the copy step.
@@ -157,14 +163,16 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
         }
 
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME);
-        Set<String> projectArtifactIds = new HashSet<>();
+        Set<String> projectArtifactKeys = new HashSet<>();
+        Set<String> projectFallbackIds = new HashSet<>();
         for (Artifact artifact : context.getProject().getArtifacts()) {
             if (!artifact.isOptional() && filter.include(artifact) && "jar".equals(artifact.getType())) {
-                projectArtifactIds.add(artifact.getArtifactId());
+                projectArtifactKeys.add(artifact.getGroupId() + ":" + artifact.getArtifactId());
+                projectFallbackIds.add(artifact.getArtifactId());
             }
         }
 
-        if (projectArtifactIds.isEmpty()) {
+        if (projectArtifactKeys.isEmpty()) {
             return Collections.emptySet();
         }
 
@@ -177,7 +185,14 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
         for (File overlayJar : overlayJars) {
             String jarName = overlayJar.getName();
             String artifactId = extractArtifactId(jarName);
-            if (artifactId != null && projectArtifactIds.contains(artifactId)) {
+            if (artifactId == null) {
+                continue;
+            }
+
+            String groupId = getJarGroupId(overlayJar);
+            String key = (groupId != null) ? groupId + ":" + artifactId : artifactId;
+            if ((groupId != null && projectArtifactKeys.contains(key))
+                    || (groupId == null && projectFallbackIds.contains(artifactId))) {
                 context.getLog()
                         .debug("Excluding dependency [" + jarName + "] from overlay [" + overlay.getId()
                                 + "]; project runtime dependencies already include a version");
@@ -185,6 +200,33 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
             }
         }
         return conflicting;
+    }
+
+    /**
+     * Reads the Maven groupId from a jar's {@code META-INF/maven/**\/pom.properties} metadata, if
+     * present.
+     *
+     * @param jarFile the jar file
+     * @return the groupId, or null if it could not be determined
+     */
+    private static String getJarGroupId(File jarFile) {
+        try (ZipFile zip = new ZipFile(jarFile)) {
+            Enumeration<? extends ZipEntry> entries = zip.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (name.startsWith("META-INF/maven/") && name.endsWith("/pom.properties")) {
+                    Properties props = new Properties();
+                    try (InputStream is = zip.getInputStream(entry)) {
+                        props.load(is);
+                    }
+                    return props.getProperty("groupId");
+                }
+            }
+        } catch (IOException e) {
+            // groupId not available; fall back to artifactId-only matching
+        }
+        return null;
     }
 
     /**
@@ -213,6 +255,9 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
      *
      * <p>Scans right-to-left for the last {@code -} followed by a digit, which correctly
      * handles artifactIds that contain digits (e.g. {@code commons-lang3-3.20.0.jar}).
+     *
+     * <p>The extracted artifactId is used together with the groupId obtained from
+     * {@link #getJarGroupId(File)} for precise {@code groupId:artifactId} matching.
      *
      * @param jarName the jar filename
      * @return the artifactId, or null if it cannot be determined

--- a/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
@@ -20,6 +20,8 @@ package org.apache.maven.plugins.war.packaging;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -65,11 +67,12 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
                 // Step1: Extract if necessary
                 final File tmpDir = unpackOverlay(context, overlay);
 
-                // Step1b: Remove jars from overlay that conflict with managed dependencies
-                filterConflictingDependencyJars(context, tmpDir);
+                // Step1b: Identify jars from overlay that conflict with project dependencies
+                Set<String> conflictingJars = computeConflictingJars(context, tmpDir);
 
-                // Step2: setup
-                final PathSet includes = getFilesToIncludes(tmpDir, overlay.getIncludes(), overlay.getExcludes());
+                // Step2: setup, excluding conflicting jars so the cached overlay is not mutated
+                String[] effectiveExcludes = mergeExcludes(overlay.getExcludes(), conflictingJars);
+                final PathSet includes = getFilesToIncludes(tmpDir, overlay.getIncludes(), effectiveExcludes);
 
                 // Copy
                 if (null == overlay.getTargetPath()) {
@@ -136,18 +139,21 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
     }
 
     /**
-     * Removes jars from the overlay's {@code WEB-INF/lib} that conflict with the project's managed
-     * dependencies. When a project uses dependencyManagement to pin a version, any jar from the
-     * overlay with the same artifactId but a different version is removed, ensuring only the
-     * dependency-managed version ends up in {@code WEB-INF/lib}.
+     * Identifies jars from the overlay's {@code WEB-INF/lib} whose artifactId matches a non-optional
+     * runtime-scope dependency resolved by the project. These jars are candidates for exclusion
+     * from the overlay copy so that only the project-resolved version ends up in {@code WEB-INF/lib}.
+     *
+     * <p>The overlay's cached unpack directory is <em>not</em> mutated; the returned set is used
+     * as additional excludes during the copy step.
      *
      * @param context the packaging context
      * @param overlayDir the unpacked overlay directory
+     * @return set of paths (relative to the overlay dir) to exclude from the overlay copy
      */
-    private void filterConflictingDependencyJars(WarPackagingContext context, File overlayDir) {
+    private Set<String> computeConflictingJars(WarPackagingContext context, File overlayDir) {
         File libDir = new File(overlayDir, "WEB-INF/lib");
         if (!libDir.isDirectory()) {
-            return;
+            return Collections.emptySet();
         }
 
         ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME);
@@ -159,32 +165,54 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
         }
 
         if (projectArtifactIds.isEmpty()) {
-            return;
+            return Collections.emptySet();
         }
 
         File[] overlayJars = libDir.listFiles((dir, name) -> name.endsWith(".jar"));
         if (overlayJars == null) {
-            return;
+            return Collections.emptySet();
         }
 
+        Set<String> conflicting = new HashSet<>();
         for (File overlayJar : overlayJars) {
             String jarName = overlayJar.getName();
             String artifactId = extractArtifactId(jarName);
             if (artifactId != null && projectArtifactIds.contains(artifactId)) {
                 context.getLog()
-                        .debug("Removing dependency [" + jarName + "] from overlay [" + overlay.getId()
-                                + "]; managed version in project already provides it");
-                if (!overlayJar.delete()) {
-                    context.getLog()
-                            .warn("Failed to delete [" + jarName + "] from overlay [" + overlay.getId() + "]");
-                }
+                        .debug("Excluding dependency [" + jarName + "] from overlay [" + overlay.getId()
+                                + "]; project runtime dependencies already include a version");
+                conflicting.add("WEB-INF/lib/" + jarName);
             }
         }
+        return conflicting;
+    }
+
+    /**
+     * Merges the overlay's existing excludes with additional jar filenames to exclude.
+     *
+     * @param overlayExcludes excludes from the overlay configuration, may be null
+     * @param additionalJars paths to add as excludes
+     * @return merged excludes array
+     */
+    private static String[] mergeExcludes(String[] overlayExcludes, Set<String> additionalJars) {
+        if (additionalJars.isEmpty()) {
+            return overlayExcludes;
+        }
+        if (overlayExcludes == null || overlayExcludes.length == 0) {
+            return additionalJars.toArray(new String[0]);
+        }
+        String[] merged = Arrays.copyOf(overlayExcludes, overlayExcludes.length + additionalJars.size());
+        System.arraycopy(
+                additionalJars.toArray(new String[0]), 0, merged, overlayExcludes.length, additionalJars.size());
+        return merged;
     }
 
     /**
      * Extracts the Maven artifactId from a jar filename following the
      * {@code artifactId-version(-classifier)?.jar} convention.
+     *
+     * <p>Scans right-to-left for the last {@code -} followed by a digit, which correctly
+     * handles artifactIds that contain digits (e.g. {@code commons-lang3-3.20.0.jar}).
      *
      * @param jarName the jar filename
      * @return the artifactId, or null if it cannot be determined
@@ -194,15 +222,10 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
             return null;
         }
         String baseName = jarName.substring(0, jarName.length() - 4);
-        int versionStart = -1;
-        for (int i = 0; i < baseName.length(); i++) {
-            if (Character.isDigit(baseName.charAt(i))) {
-                versionStart = i;
-                break;
+        for (int i = baseName.length() - 2; i >= 0; i--) {
+            if (baseName.charAt(i) == '-' && Character.isDigit(baseName.charAt(i + 1))) {
+                return baseName.substring(0, i);
             }
-        }
-        if (versionStart > 0 && baseName.charAt(versionStart - 1) == '-') {
-            return baseName.substring(0, versionStart - 1);
         }
         return null;
     }

--- a/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
@@ -174,7 +174,10 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
                 context.getLog()
                         .debug("Removing dependency [" + jarName + "] from overlay [" + overlay.getId()
                                 + "]; managed version in project already provides it");
-                overlayJar.delete();
+                if (!overlayJar.delete()) {
+                    context.getLog()
+                            .warn("Failed to delete [" + jarName + "] from overlay [" + overlay.getId() + "]");
+                }
             }
         }
     }

--- a/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
+++ b/src/main/java/org/apache/maven/plugins/war/packaging/OverlayPackagingTask.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.war.Overlay;
 import org.apache.maven.plugins.war.util.PathSet;
@@ -149,9 +150,10 @@ public class OverlayPackagingTask extends AbstractWarPackagingTask {
             return;
         }
 
+        ScopeArtifactFilter filter = new ScopeArtifactFilter(Artifact.SCOPE_RUNTIME);
         Set<String> projectArtifactIds = new HashSet<>();
         for (Artifact artifact : context.getProject().getArtifacts()) {
-            if (!artifact.isOptional() && "jar".equals(artifact.getType())) {
+            if (!artifact.isOptional() && filter.include(artifact) && "jar".equals(artifact.getType())) {
                 projectArtifactIds.add(artifact.getArtifactId());
             }
         }


### PR DESCRIPTION
 Fixes #389

When a project uses dependencyManagement to pin a specific version of a library, any jar in a WAR overlay's `WEB-INF/lib` with the same artifactId but a different version will now be removed during overlay processing.

### How it works
In `OverlayPackagingTask.performPackaging()`, after unpacking the overlay and before copying files, the new `filterConflictingDependencyJars()` method scans the overlay's `WEB-INF/lib` directory. For each jar, it extracts the artifactId from the filename (following the `artifactId-version(-classifier)?.jar` convention). If the artifactId matches a non-optional jar artifact from the project's dependency tree, the overlay jar is removed — the managed version will be provided by the project's own dependency resolution.

### Additional changes
- Updated the MWAR-389 IT test (`verify.bsh`) to remove print statements for the passing case per review feedback.

The IT test in PR #638 documents this issue and now passes with this fix applied.