### PR TITLE
[MWAR-446] Add compressLibs option to store dependency JARs in STORED mode

### DIFF
--- a/src/it/MWAR-446/pom.xml
+++ b/src/it/MWAR-446/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>foo.bar</groupId>
+  <artifactId>MWAR-446</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>war</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <configuration>
+          <failOnMissingWebXml>false</failOnMissingWebXml>
+          <compressLibs>false</compressLibs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>@plexusUtilVersion@</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/MWAR-446/src/main/webapp/index.html
+++ b/src/it/MWAR-446/src/main/webapp/index.html
@@ -1,0 +1,3 @@
+<html>
+<body>Hello World</body>
+</html>

--- a/src/it/MWAR-446/src/main/webapp/index.html
+++ b/src/it/MWAR-446/src/main/webapp/index.html
@@ -1,3 +1,23 @@
+<!--
+
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+-->
 <html>
 <body>Hello World</body>
 </html>

--- a/src/it/MWAR-446/verify.groovy
+++ b/src/it/MWAR-446/verify.groovy
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+def warFile = new File(basedir, 'target/MWAR-446-0.0.1-SNAPSHOT.war')
+assert warFile.exists() : "WAR file should exist"
+
+def zipFile = new ZipFile(warFile)
+try {
+    def foundStoredJar = false
+    def foundDeflatedEntry = false
+
+    zipFile.entries().each { ZipEntry entry ->
+        if (entry.name.startsWith('WEB-INF/lib/') && entry.name.endsWith('.jar')) {
+            assert entry.method == ZipEntry.STORED :
+                "JAR entry ${entry.name} should be STORED (method=0) but was method=${entry.method}"
+            foundStoredJar = true
+        }
+        if (entry.name == 'index.html') {
+            assert entry.method == ZipEntry.DEFLATED :
+                "index.html should be DEFLATED (method=8) but was method=${entry.method}"
+            foundDeflatedEntry = true
+        }
+    }
+
+    assert foundStoredJar : "Should have found at least one JAR in WEB-INF/lib/"
+    assert foundDeflatedEntry : "Should have found index.html"
+} finally {
+    zipFile.close()
+}

--- a/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/war/AbstractWarMojo.java
@@ -312,6 +312,18 @@ public abstract class AbstractWarMojo extends AbstractMojo {
     private boolean recompressZippedFiles;
 
     /**
+     * Whether dependency libraries (i.e. JAR files in {@code WEB-INF/lib/}) should be compressed (DEFLATED) when
+     * added to the WAR archive. Setting this to {@code false} will store the library JARs without compression
+     * (STORED mode), which can improve servlet container startup time since the JARs do not need to be decompressed.
+     * Note that since JAR files are already compressed, storing them without additional compression typically has
+     * negligible impact on the overall WAR file size.
+     *
+     * @since 3.5.2
+     */
+    @Parameter(defaultValue = "true")
+    private boolean compressLibs;
+
+    /**
      * @since 2.4
      */
     @Parameter(defaultValue = "false")
@@ -1050,6 +1062,14 @@ public abstract class AbstractWarMojo extends AbstractMojo {
      */
     protected boolean isRecompressZippedFiles() {
         return recompressZippedFiles;
+    }
+
+    /**
+     * @return {@link #compressLibs}
+     * @since 3.5.2
+     */
+    protected boolean isCompressLibs() {
+        return compressLibs;
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/war/WarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/war/WarMojo.java
@@ -48,6 +48,8 @@ import org.codehaus.plexus.archiver.jar.ManifestException;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.war.WarArchiver;
+import org.codehaus.plexus.archiver.zip.ConcurrentJarCreator;
+import org.codehaus.plexus.components.io.functions.InputStreamSupplier;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
@@ -386,9 +388,52 @@ public class WarMojo extends AbstractWarMojo {
 
     public WarArchiver getWarArchiver() {
         try {
-            return (WarArchiver) getArchiverManager().getArchiver("war");
+            if (isCompressLibs()) {
+                return (WarArchiver) getArchiverManager().getArchiver("war");
+            } else {
+                return new UncompressedLibsWarArchiver();
+            }
         } catch (NoSuchArchiverException e) {
             throw new IllegalStateException("Cannot find war archiver", e);
+        }
+    }
+
+    /**
+     * A {@link WarArchiver} subclass that stores dependency library JARs ({@code WEB-INF/lib/*.jar})
+     * in STORED mode (uncompressed) instead of DEFLATED mode, while still compressing all other entries.
+     * This improves servlet container startup time since the already-compressed JARs are not
+     * decompressed and recompressed during WAR creation and extraction.
+     */
+    private static class UncompressedLibsWarArchiver extends WarArchiver {
+
+        UncompressedLibsWarArchiver() {
+            super();
+        }
+
+        @Override
+        // CHECKSTYLE_OFF: ParameterNumber
+        protected void zipFile(
+                InputStreamSupplier in,
+                ConcurrentJarCreator zOut,
+                String vPath,
+                long lastModified,
+                File fromArchive,
+                int mode,
+                String symlinkDestination,
+                boolean addInParallel)
+                throws IOException, ArchiverException {
+            // CHECKSTYLE_ON: ParameterNumber
+            if (vPath.startsWith("WEB-INF/lib/") && !vPath.endsWith("/")) {
+                boolean original = isCompress();
+                setCompress(false);
+                try {
+                    super.zipFile(in, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination, addInParallel);
+                } finally {
+                    setCompress(original);
+                }
+            } else {
+                super.zipFile(in, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination, addInParallel);
+            }
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/war/WarMojo.java
+++ b/src/main/java/org/apache/maven/plugins/war/WarMojo.java
@@ -43,13 +43,13 @@ import org.apache.maven.plugins.war.util.ClassesPackager;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenResourcesFiltering;
+import org.codehaus.plexus.archiver.ArchiveEntry;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.jar.ManifestException;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.war.WarArchiver;
 import org.codehaus.plexus.archiver.zip.ConcurrentJarCreator;
-import org.codehaus.plexus.components.io.functions.InputStreamSupplier;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
@@ -411,28 +411,18 @@ public class WarMojo extends AbstractWarMojo {
         }
 
         @Override
-        // CHECKSTYLE_OFF: ParameterNumber
-        protected void zipFile(
-                InputStreamSupplier in,
-                ConcurrentJarCreator zOut,
-                String vPath,
-                long lastModified,
-                File fromArchive,
-                int mode,
-                String symlinkDestination,
-                boolean addInParallel)
+        protected void zipFile(ArchiveEntry entry, ConcurrentJarCreator zOut, String vPath)
                 throws IOException, ArchiverException {
-            // CHECKSTYLE_ON: ParameterNumber
             if (vPath.startsWith("WEB-INF/lib/") && !vPath.endsWith("/")) {
                 boolean original = isCompress();
                 setCompress(false);
                 try {
-                    super.zipFile(in, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination, addInParallel);
+                    super.zipFile(entry, zOut, vPath);
                 } finally {
                     setCompress(original);
                 }
             } else {
-                super.zipFile(in, zOut, vPath, lastModified, fromArchive, mode, symlinkDestination, addInParallel);
+                super.zipFile(entry, zOut, vPath);
             }
         }
     }


### PR DESCRIPTION
Fixes #526

Add a new `compressLibs` parameter (default: `true`) to the maven-war-plugin. When set to `false`, dependency library JARs in `WEB-INF/lib/` are stored in the WAR archive using STORED mode (no compression) instead of DEFLATED mode.

**Why:** JAR files are already compressed internally. Re-compressing them when adding to a WAR provides negligible size reduction but adds CPU overhead during both WAR creation and servlet container startup (the JARs must be decompressed before they can be loaded). Storing them in STORED mode eliminates this redundant compression.

**Implementation:** Creates an `UncompressedLibsWarArchiver` subclass of `WarArchiver` that overrides `zipFile()` to temporarily disable compression for entries under `WEB-INF/lib/`, while all other entries (classes, resources, web.xml, etc.) continue to be compressed normally.

**Usage:**
```xml
<configuration>
  <compressLibs>false</compressLibs>
</configuration>
```

**Changes:**
- `AbstractWarMojo.java`: Added `compressLibs` parameter with getter
- `WarMojo.java`: Added `UncompressedLibsWarArchiver` inner class; `getWarArchiver()` returns it when `compressLibs=false`
- Integration test `MWAR-446` verifying JARs are STORED and other entries are DEFLATED