### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/adding-filtering-webresources.md.vm
+++ b/src/site/markdown/examples/adding-filtering-webresources.md.vm
@@ -1,3 +1,11 @@
+---
+title: Adding and Filtering External Web Resources
+author: 
+  - Pete Marvin King
+  - Dennis Lundberg
+date: 2012-09-28
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/file-name-mapping.md
+++ b/src/site/markdown/examples/file-name-mapping.md
@@ -1,3 +1,11 @@
+---
+title: Using File Name Mapping
+author: 
+  - Stephane Nicoll
+  - Dennis Lundberg
+date: 2010-05-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/including-excluding-files-from-war.md.vm
+++ b/src/site/markdown/examples/including-excluding-files-from-war.md.vm
@@ -1,3 +1,10 @@
+---
+title: Including and Excluding Files From the WAR
+author: 
+  - Dennis Lundberg
+date: 2011-11-21
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/rapid-testing-jetty6-plugin.md
+++ b/src/site/markdown/examples/rapid-testing-jetty6-plugin.md
@@ -1,3 +1,10 @@
+---
+title: Rapid Testing Using the Jetty Plugin
+author: 
+  - Pete Marvin King
+date: 2008-08-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/war-manifest-guide.md.vm
+++ b/src/site/markdown/examples/war-manifest-guide.md.vm
@@ -1,3 +1,10 @@
+---
+title: WAR Manifest Customization
+author: 
+  - Pete Marvin King
+date: 2008-08-03
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Pete Marvin King
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/overlays.md.vm
+++ b/src/site/markdown/overlays.md.vm
@@ -1,3 +1,12 @@
+---
+title: Overlays
+author: 
+  - Pete Marvin King
+  - Stephane Nicoll
+  - Dennis Lundberg
+date: 2010-08-14
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,10 @@
+---
+title: Usage
+author: 
+  - Pete Marvin King
+date: 2010-08-15
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.